### PR TITLE
Fix subtitles won't show, any source, iina#3431

### DIFF
--- a/iina/JustXMLRPC.swift
+++ b/iina/JustXMLRPC.swift
@@ -21,6 +21,7 @@ class JustXMLRPC {
     var readableDescription: String {
       return "\(method): [\(httpCode)] \(reason)"
     }
+    var underlyingError: Error?
   }
 
   enum Result {
@@ -74,7 +75,7 @@ class JustXMLRPC {
         }
       } else {
         // http error
-        callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0, reason: response.reason)))
+        callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0, reason: response.reason, underlyingError: response.error)))
       }
     }
   }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -367,9 +367,15 @@ extension MainMenuActionHandler {
     }
     let subURL = URL(fileURLWithPath: path)
     let subFileName = subURL.lastPathComponent
-    let destURL = currURL.deletingLastPathComponent().appendingPathComponent(subFileName, isDirectory: false)
     do {
+      // When streaming save the subtitles file to the user's ~/Movies directory, otherwise
+      // save the file to the same directory the video is in.
+      let destDirURL = player.info.isNetworkResource ? try FileManager.default.url(
+          for: .moviesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        : currURL.deletingLastPathComponent()
+      let destURL = destDirURL.appendingPathComponent(subFileName, isDirectory: false)
       try FileManager.default.copyItem(at: subURL, to: destURL)
+      Logger.log("Saved downloaded subtitles to \(destURL.path)")
       player.sendOSD(.savedSub)
     } catch let error as NSError {
       Utility.showAlert("error_saving_file", arguments: ["subtitle",

--- a/iina/ShooterSubtitle.swift
+++ b/iina/ShooterSubtitle.swift
@@ -10,6 +10,8 @@ import Foundation
 import Just
 import PromiseKit
 
+fileprivate let subsystem = Logger.Subsystem(rawValue: "shooter")
+
 final class ShooterSubtitle: OnlineSubtitle {
 
   var desc: String
@@ -63,9 +65,10 @@ class ShooterSupport {
 
   enum ShooterError: Error {
     // file error
-    case cannotReadFile
+    case cannotReadFile(Error)
     case fileTooSmall
-    case networkError
+    case networkError(Error?)
+    case noResult
   }
 
   typealias ResponseData = [[String: Any]]
@@ -82,10 +85,14 @@ class ShooterSupport {
 
   func hash(_ url: URL) -> Promise<FileInfo> {
     return Promise { resolver in
-      guard let file = try? FileHandle(forReadingFrom: url) else {
-        resolver.reject(ShooterError.cannotReadFile)
+      var file: FileHandle
+      do {
+        file = try FileHandle(forReadingFrom: url)
+      } catch {
+        resolver.reject(ShooterError.cannotReadFile(error))
         return
       }
+      defer { file.closeFile() }
 
       file.seekToEndOfFile()
       let fileSize: UInt64 = file.offsetInFile
@@ -107,8 +114,6 @@ class ShooterSupport {
         return file.readData(ofLength: chunkSize).md5
         }.joined(separator: ";")
 
-      file.closeFile()
-
       resolver.fulfill(FileInfo(hashValue: hash, path: url.path))
     }
   }
@@ -117,11 +122,11 @@ class ShooterSupport {
     return Promise { resolver in
       Just.post(apiPath, params: info.dictionary, timeout: 10) { response in
         guard response.ok else {
-          resolver.reject(ShooterError.networkError)
+          resolver.reject(ShooterError.networkError(response.error))
           return
         }
         guard let json = response.json as? ResponseData else {
-          resolver.fulfill([])
+          resolver.reject(ShooterError.noResult)
           return
         }
 


### PR DESCRIPTION
This commit will:

- Change OpenSubSubtitle.hash to throw noResult if the video is being
    streamed
- Change OpenSubSubtitle.requestIMDB to use the media title as the text
    for the lookup if the video is being streamed
- Change MainMenuActions.saveDownloadedSub to copy downloaded subtitles
    from streamed files to "~/Movies"
- Change OnlineSubtitle.getSubtitle to correct a failure to display the
    OSD when using shooter.cn
- Change OpenSubSubtitle.hash and ShooterSubtitle.hash to ensure file
    is closed
- Improve logging when obtaining subtitles

With these changes subtitles can be downloaded and viewed for movies
streamed from YouTube and from Dailymotion when using OpenSubtitles.org.

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
